### PR TITLE
lib/presets: fix nested changelog

### DIFF
--- a/lib/presets.js
+++ b/lib/presets.js
@@ -847,7 +847,7 @@ module.exports = {
   template: {
     'nested-changelogs': [
       '{{#*inline "commits"}}',
-      '{{nesting}} v{{version}}:',
+      '{{nesting}} {{#eq nesting "#"}}v{{else}}{{/eq}}{{version}}:',
       '{{nesting}}# ({{moment date "Y-MM-DD"}})',
       '',
       '{{#each commits}}',

--- a/tests/cli/cases/nested-changelog.js
+++ b/tests/cli/cases/nested-changelog.js
@@ -70,7 +70,7 @@ m.chai.expect(shelljs.cat('CHANGELOG.md').stdout).to.deep.equal([
   '<details>',
   '<summary> View details </summary>',
   '',
-  '## v0.1.1:',
+  '## 0.1.1:',
   '### (2018-09-23)',
   '',
   '* foo [Bar]',


### PR DESCRIPTION
Remove extra "v" appearing before version in nested changelogs

Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@resin.io>