### PR TITLE
Do not reject cherry-picked commits

### DIFF
--- a/src/tags.ts
+++ b/src/tags.ts
@@ -93,7 +93,11 @@ export const parseFooterTagLines = (
 ): _.Dictionary<string> => {
 	return _.chain(footerTagLines)
 		.reject(line => {
-			return _.isEmpty(line.trim());
+			line = line.trim();
+			return (
+				_.isEmpty(line) ||
+				/^\(cherry\spicked\sfrom\scommit\s[0-9a-f]{7,40}\)$/.test(line)
+			);
 		})
 		.reduce((tags: Array<[string, string?]>, tagLine) => {
 			const tag = parseTagLine(tagLine);

--- a/tests/tags.spec.js
+++ b/tests/tags.spec.js
@@ -238,6 +238,31 @@ describe('Tags', function() {
         bar: 'baz'
       });
     });
-  });
 
+    it('should ignore signed cherry-pick lines (long commit)', function() {
+      const footer = tags.parseFooterTagLines([
+        'Foo: bar',
+        '(cherry picked from commit 15b916f6bbbbbe2c9dfd5bad2a92aa5c3c8d49a6)',
+        'bar: baz'
+      ]);
+
+      m.chai.expect(footer).to.deep.equal({
+        Foo: 'bar',
+        bar: 'baz'
+      });
+    });
+
+    it('should ignore signed cherry-pick lines (short commit)', function() {
+      const footer = tags.parseFooterTagLines([
+        'Foo: bar',
+        '(cherry picked from commit 15b916f)',
+        'bar: baz'
+      ]);
+
+      m.chai.expect(footer).to.deep.equal({
+        Foo: 'bar',
+        bar: 'baz'
+      });
+    });
+  });
 });


### PR DESCRIPTION
Currently commits that result from running `git cherry-pick -x COMMIT`
are not allowed by versionist.

Connects-to: https://github.com/balena-io/versionist/issues/133
Signed-off-by: Robert Günzler <robertg@balena.io>