### PR TITLE
Add getIncrementLevelFromCommit options

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -386,19 +386,74 @@ module.exports = {
      * @returns {String} Increment level
      *
      * @example
-     * if (presets.includeCommitWhen['has-changetype']({}, {
+     * if (presets.getIncrementLevelFromCommit['change-type']({}, {
      *   subject: 'A change',
      *   footer: {
      *     'change-type': 'minor'
      *   }
      * })) {
-     *   console.log('The commit should be included');
+     *   console.log('minor');
      * }
      */
     'change-type': (options, commit) => {
       if (isIncrementalCommit(commit.footer['change-type'])) {
         return commit.footer['change-type'].trim().toLowerCase();
       }
+    },
+
+    /**
+     * @summary Calculate increment level from subject
+     * @function
+     * @public
+     *
+     *
+     * @param {Object} options - options
+     * @param {Object} commit - commit
+     * @returns {String} Increment level
+     *
+     * @example
+     * if (presets.getIncrementLevelFromCommit['title']({}, {
+     *   subject: 'patch: a change',
+     *   footer: {
+     *     'foo': 'bar'
+     *   }
+     * })) {
+     *   console.log('patch');
+     * }
+     */
+    subject: (options, commit) => {
+      const match = commit.subject.match(/(patch|minor|major)/);
+      if (_.isArray(match) && isIncrementalCommit(match[1])) {
+        return match[1].trim().toLowerCase();
+      }
+    },
+
+    /**
+     * @summary Calculate increment level from footers or title if not change-type footer is present
+     * @function
+     * @public
+     *
+     *
+     * @param {Object} options - options
+     * @param {Object} commit - commit
+     * @returns {String} Increment level
+     *
+     * @example
+     * if (presets.getIncrementLevelFromCommit.changeTypeOrSubject({}, {
+     *   subject: 'patch: a change',
+     *   footer: {
+     *     'change-type': 'minor'
+     *   }
+     * })) {
+     *   console.log('minor');
+     * }
+     */
+    changeTypeOrSubject: (options, commit) => {
+      const ctIncrement = module.exports.getIncrementLevelFromCommit['change-type'](options, commit);
+      if (_.isString(ctIncrement)) {
+        return ctIncrement;
+      }
+      return module.exports.getIncrementLevelFromCommit.subject(options, commit);
     }
   },
 

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -2541,6 +2541,72 @@ describe('Presets', function() {
     });
 
   });
+  describe('.getIncrementLevelFromCommit', () => {
+
+    describe('.subject', () => {
+
+      it('should extract increment level from commit subject', () => {
+        const data = {
+          subject: 'patch: rest of subject',
+          footer: {
+            foo: 'bar'
+          }
+        };
+        const incrementLevel = presets.getIncrementLevelFromCommit.subject({}, data);
+        m.chai.expect(incrementLevel).to.equal('patch');
+      });
+    });
+
+    describe('.change-type', () => {
+
+      it('should extract increment level from commit footers', () => {
+        const data = {
+          subject: 'subject',
+          footer: {
+            'change-type': 'patch'
+          }
+        };
+        const incrementLevel = presets.getIncrementLevelFromCommit['change-type']({}, data);
+        m.chai.expect(incrementLevel).to.equal('patch');
+      });
+    });
+
+    describe('.changeTypeOrSubject', () => {
+
+      it('should extract increment level from commit footers', () => {
+        const data = {
+          subject: 'subject',
+          footer: {
+            'change-type': 'patch'
+          }
+        };
+        const incrementLevel = presets.getIncrementLevelFromCommit.changeTypeOrSubject({}, data);
+        m.chai.expect(incrementLevel).to.equal('patch');
+      });
+
+      it('should extract increment level from commit subject', () => {
+        const data = {
+          subject: 'patch: subject',
+          footer: {
+            foo: 'bar'
+          }
+        };
+        const incrementLevel = presets.getIncrementLevelFromCommit.changeTypeOrSubject({}, data);
+        m.chai.expect(incrementLevel).to.equal('patch');
+      });
+
+      it('should prefer increment level from footers over the one in the title', () => {
+        const data = {
+          subject: 'minor: subject',
+          footer: {
+            'change-type': 'patch'
+          }
+        };
+        const incrementLevel = presets.getIncrementLevelFromCommit.changeTypeOrSubject({}, data);
+        m.chai.expect(incrementLevel).to.equal('patch');
+      });
+    });
+  });
 
   describe('.transformTemplateData', () => {
 


### PR DESCRIPTION
Added subject, which extracts increment level from the prefix in the
commit subject

Added changeTypeOrSubject which tries to extract the increment from the
change type at first, and if that fails tries to extract it from the
subject instead

Change-type: minor
Fixes: #164 
Signed-off-by: Giovanni Garufi <giovanni@balena.io>