### PR TITLE
Fix authentication

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -34,14 +34,8 @@ const { Octokit } = require('@octokit/rest');
 
 const octokit = new Octokit({
 	debug: Boolean(process.env.DEBUG),
+	auth: process.env.GITHUB_TOKEN,
 });
-
-const authenticate = () => {
-	octokit.authenticate({
-		type: 'token',
-		token: process.env.GITHUB_TOKEN,
-	});
-};
 
 // prettier-ignore
 const templateDefaults = [


### PR DESCRIPTION
`octokit.authenticate` was removed in v17 as part of the
> All deprecated methods and options have been removed. Upgrade to the latest 16.x.x version and address all deprecation messages for an easy upgrade.

message, the problem is since we only try to authenticate for nested changelogs it was very rare for the deprecation notice to be printed. This should fix that