### PR TITLE
Guarantee the order of nested changelogs

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -152,7 +152,7 @@ const getNestedChangeLog = (
 };
 
 const attachNestedChangelog = (upstreams, commit, callback) => {
-	async.each(
+	async.map(
 		upstreams,
 		(upstream, cb) => {
 			const regexp = new RegExp(
@@ -167,19 +167,13 @@ const attachNestedChangelog = (upstreams, commit, callback) => {
 					commit,
 					currentVersion,
 					targetVersion,
-					(err, nestedCommits) => {
-						if (err) {
-							return callback(err);
-						}
-						commit.nested = commit.nested || [];
-						commit.nested = commit.nested.concat(nestedCommits);
-						return cb(null);
-					},
+					cb,
 				);
 			}
 			return cb(null);
 		},
-		(err) => {
+		(err, nestedCommits) => {
+			commit.nested = _(nestedCommits).compact().flatten().value();
 			return callback(err, commit);
 		},
 	);


### PR DESCRIPTION
Previously the order of nested changelogs was dependent on a race
condition, now it will always be consistent regardless of how long
fetching the nested entries takes

Change-type: patch