### PR TITLE
Make change-type checks case insensitive

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -104,9 +104,9 @@ const getAuthor = (commitHash) => {
 };
 
 const getChangeType = (footer) => {
-	const changeType =
-		footer[Object.keys(footer).find((k) => k.toLowerCase() === 'change-type')];
-	return changeType;
+	return footer[
+		Object.keys(footer).find((k) => k.toLowerCase() === 'change-type')
+	];
 };
 
 const extractContentsBetween = (changelog, repo, start, end) => {

--- a/src/presets.js
+++ b/src/presets.js
@@ -448,7 +448,7 @@ module.exports = {
 			if (!_.isString(commit.subject)) {
 				return null;
 			}
-			const match = commit.subject.match(/(patch|minor|major)/);
+			const match = commit.subject.match(/(patch|minor|major)/i);
 			if (_.isArray(match) && isIncrementalCommit(match[1])) {
 				return match[1].trim().toLowerCase();
 			}

--- a/src/presets.js
+++ b/src/presets.js
@@ -103,6 +103,12 @@ const getAuthor = (commitHash) => {
 	return 'Unknown author';
 };
 
+const getChangeType = (footer) => {
+	const changeType =
+		footer[Object.keys(footer).find((k) => k.toLowerCase() === 'change-type')];
+	return changeType;
+};
+
 const extractContentsBetween = (changelog, repo, start, end) => {
 	return _(changelog)
 		.filter((entry) => {
@@ -355,8 +361,9 @@ module.exports = {
 		 * }
 		 */
 		'has-changetype': (options, commit) => {
+			const changeType = getChangeType(commit.footer);
 			return (
-				isIncrementalCommit(commit.footer['change-type']) ||
+				isIncrementalCommit(changeType) ||
 				isIncrementalCommit(
 					module.exports.getIncrementLevelFromCommit.subject({}, commit),
 				)
@@ -410,8 +417,10 @@ module.exports = {
 		 * }
 		 */
 		'change-type': (options, commit) => {
-			if (isIncrementalCommit(commit.footer['change-type'])) {
-				return commit.footer['change-type'].trim().toLowerCase();
+			const changeType = getChangeType(commit.footer);
+
+			if (isIncrementalCommit(changeType)) {
+				return changeType.trim().toLowerCase();
 			}
 		},
 

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -302,6 +302,41 @@ describe('Presets', function () {
 				).to.be.false;
 			});
 		});
+
+		describe('.has-changetype', function () {
+			it('should return true if has has change-type lower case', function () {
+				const data = {
+					subject: 'subject',
+					footer: {
+						'change-type': 'patch',
+					},
+				};
+				m.chai.expect(presets.includeCommitWhen['has-changetype']({}, data)).to
+					.be.true;
+			});
+
+			it('should return true if has has change-type titled', function () {
+				const data = {
+					subject: 'subject',
+					footer: {
+						'Change-Type': 'patch',
+					},
+				};
+				m.chai.expect(presets.includeCommitWhen['has-changetype']({}, data)).to
+					.be.true;
+			});
+
+			it('should return fase if has has no change-type', function () {
+				const data = {
+					subject: 'subject',
+					footer: {
+						'missing-change-type': 'patch',
+					},
+				};
+				m.chai.expect(presets.includeCommitWhen['has-changetype']({}, data)).to
+					.be.false;
+			});
+		});
 	});
 
 	describe('.getChangelogDocumentedVersions', function () {
@@ -3161,11 +3196,24 @@ describe('Presets', function () {
 		});
 
 		describe('.change-type', () => {
-			it('should extract increment level from commit footers', () => {
+			it('should extract increment level from commit footers lower case', () => {
 				const data = {
 					subject: 'subject',
 					footer: {
 						'change-type': 'patch',
+					},
+				};
+				const incrementLevel = presets.getIncrementLevelFromCommit[
+					'change-type'
+				]({}, data);
+				m.chai.expect(incrementLevel).to.equal('patch');
+			});
+
+			it('should extract increment level from commit footers titled', () => {
+				const data = {
+					subject: 'subject',
+					footer: {
+						'Change-Type': 'patch',
 					},
 				};
 				const incrementLevel = presets.getIncrementLevelFromCommit[


### PR DESCRIPTION
Make commit footer change-type checks case insensitive, to remove contribution friction.

Change-type: minor
Signed-off-by: Stathis Moraitidis <stathis@balena.io>